### PR TITLE
Fix code scanning alert no. 2: Code injection

### DIFF
--- a/app/controllers/api/v1/mobile_controller.rb
+++ b/app/controllers/api/v1/mobile_controller.rb
@@ -5,15 +5,19 @@ class Api::V1::MobileController < ApplicationController
 
   respond_to :json
 
+  ALLOWED_CLASSES = ['User', 'Product', 'Order'].freeze
+
   def show
-    if params[:class]
+    if params[:class] && ALLOWED_CLASSES.include?(params[:class].classify)
       model = params[:class].classify.constantize
       respond_with model.find(params[:id]).to_json
+    else
+      render json: { error: 'Invalid class parameter' }, status: :bad_request
     end
   end
 
   def index
-    if params[:class]
+    if params[:class] && ALLOWED_CLASSES.include?(params[:class].classify)
       model = params[:class].classify.constantize
       respond_with model.all.to_json
     else


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/2](https://github.com/Brook-5686/Ruby_3/security/code-scanning/2)

To fix this issue, we should avoid directly using user input to determine the class. Instead, we can use a whitelist of allowed classes and only allow the user to select from this predefined list. This approach ensures that only safe, expected classes can be used, preventing any potential code injection.

1. Define a whitelist of allowed classes.
2. Check if the user-provided class is in the whitelist.
3. If it is, proceed with the operation; otherwise, handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
