### PR TITLE
Fix code scanning alert no. 13: Insecure Mass Assignment

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,7 +47,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit!
+    params.require(:user).permit(:email, :first_name, :last_name, :password, :password_confirmation)
   end
 
   # unpermitted attributes are ignored in production


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/13](https://github.com/Brook-5686/Ruby_3/security/code-scanning/13)

To fix the problem, we need to restrict the parameters that can be assigned to the `User` object by explicitly specifying the allowed parameters. This can be done by modifying the `user_params` method to use `permit` with a list of allowed attributes. This change ensures that only the specified attributes can be mass-assigned, preventing unintended attributes from being set.

1. Modify the `user_params` method to explicitly permit only the necessary attributes.
2. Ensure that the `create` and `update` methods use the updated `user_params` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
