### PR TITLE
Fix code scanning alert no. 4: Code injection

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -13,7 +13,14 @@ class DashboardController < ApplicationController
   end
 
   def change_graph
-    self.try(params[:graph])
+    allowed_graphs = ["bar_graph", "pie_charts"]
+    if allowed_graphs.include?(params[:graph])
+      self.try(params[:graph])
+    else
+      # Handle invalid graph type
+      render plain: "Invalid graph type", status: :bad_request
+      return
+    end
 
     if params[:graph] == "bar_graph"
       render "dashboard/bar_graph"


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/4](https://github.com/Brook-5686/Ruby_3/security/code-scanning/4)

To fix the problem, we need to ensure that the user input is validated and only allows specific, expected values. This can be done by using a whitelist of allowed method names and checking the user input against this list before calling the method.

- Create a whitelist of allowed graph types.
- Check if the `params[:graph]` value is included in the whitelist.
- Only call the method if the value is valid; otherwise, handle the invalid input appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
