### PR TITLE
Fix code scanning alert no. 3: Code injection

### DIFF
--- a/app/controllers/benefit_forms_controller.rb
+++ b/app/controllers/benefit_forms_controller.rb
@@ -8,8 +8,14 @@ class BenefitFormsController < ApplicationController
   def download
    begin
      path = params[:name]
-     file = params[:type].constantize.new(path)
-     send_file file, disposition: "attachment"
+     allowed_types = ["AllowedType1", "AllowedType2"] # Replace with actual allowed types
+     if allowed_types.include?(params[:type])
+       file = params[:type].constantize.new(path)
+       send_file file, disposition: "attachment"
+     else
+       flash[:error] = "Invalid file type"
+       redirect_to user_benefit_forms_path(user_id: current_user.id) and return
+     end
    rescue
      redirect_to user_benefit_forms_path(user_id: current_user.id)
    end


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/3](https://github.com/Brook-5686/Ruby_3/security/code-scanning/3)

To fix the problem, we need to ensure that the user input is properly validated before being used with `constantize`. One way to do this is to maintain a whitelist of allowed types and check the user input against this list. If the input is not in the whitelist, we can raise an error or handle it appropriately.

- Create a whitelist of allowed types.
- Check if `params[:type]` is in the whitelist before calling `constantize`.
- If the type is not allowed, handle the error gracefully.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
