### PR TITLE
Fix code scanning alert no. 8: Uncontrolled command line

### DIFF
--- a/app/models/benefits.rb
+++ b/app/models/benefits.rb
@@ -3,16 +3,17 @@ class Benefits < ApplicationRecord
 
   def self.save(file, backup = false)
     data_path = Rails.root.join("public", "data")
-    full_file_name = "#{data_path}/#{file.original_filename}"
+    sanitized_filename = sanitize_filename(file.original_filename)
+    full_file_name = "#{data_path}/#{sanitized_filename}"
     f = File.open(full_file_name, "wb+")
     f.write file.read
     f.close
-    make_backup(file, data_path, full_file_name) if backup == "true"
+    make_backup(sanitized_filename, data_path, full_file_name) if backup == "true"
   end
 
-  def self.make_backup(file, data_path, full_file_name)
+  def self.make_backup(filename, data_path, full_file_name)
     if File.exist?(full_file_name)
-      silence_streams(STDERR) { system("cp #{full_file_name} #{data_path}/bak#{Time.zone.now.to_i}_#{file.original_filename}") }
+      silence_streams(STDERR) { system("cp #{full_file_name} #{data_path}/bak#{Time.zone.now.to_i}_#{filename}") }
     end
   end
 
@@ -27,5 +28,8 @@ class Benefits < ApplicationRecord
     streams.each_with_index do |stream, i|
       stream.reopen(on_hold[i])
     end
+  end
+  def self.sanitize_filename(filename)
+    filename.gsub(/[^0-9A-Za-z.\-_]/, '_')
   end
 end


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/8](https://github.com/Brook-5686/Ruby_3/security/code-scanning/8)

To fix the problem, we need to ensure that the user-provided filename is sanitized before it is used in the `system` call. One way to achieve this is by using a whitelist of allowed characters and removing any potentially dangerous characters from the filename. This can be done using a regular expression to only allow alphanumeric characters and a few safe symbols (e.g., underscores and hyphens).

We will create a method to sanitize the filename and use it before constructing the command string. This ensures that the filename does not contain any malicious content that could lead to command injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
