### PR TITLE
Fix code scanning alert no. 2: Code injection

### DIFF
--- a/app/controllers/api/v1/mobile_controller.rb
+++ b/app/controllers/api/v1/mobile_controller.rb
@@ -5,11 +5,15 @@ class Api::V1::MobileController < ApplicationController
 
   respond_to :json
 
-  ALLOWED_CLASSES = ['User', 'Product', 'Order'].freeze
+  ALLOWED_CLASSES = {
+    'User' => User,
+   'Product' => Product,
+   'Order' => Order
+ }.freeze
 
   def show
     if params[:class] && ALLOWED_CLASSES.include?(params[:class].classify)
-      model = params[:class].classify.constantize
+      model = ALLOWED_CLASSES[params[:class].classify]
       respond_with model.find(params[:id]).to_json
     else
       render json: { error: 'Invalid class parameter' }, status: :bad_request
@@ -18,7 +22,7 @@ class Api::V1::MobileController < ApplicationController
 
   def index
     if params[:class] && ALLOWED_CLASSES.include?(params[:class].classify)
-      model = params[:class].classify.constantize
+      model = ALLOWED_CLASSES[params[:class].classify]
       respond_with model.all.to_json
     else
       respond_with nil.to_json


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/2](https://github.com/Brook-5686/Ruby_3/security/code-scanning/2)

To fix the problem, we should avoid using `constantize` on user input. Instead, we can use a hash map to map the allowed class names to their corresponding class objects. This way, we can safely reference the class objects without dynamically evaluating user input.

- Create a hash map that maps allowed class names to their corresponding class objects.
- Use this hash map to retrieve the class object based on the user-provided class name.
- Replace the use of `constantize` with a lookup in the hash map.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
