### PR TITLE
Fix code scanning alert no. 68: Code injection

### DIFF
--- a/app/controllers/benefit_forms_controller.rb
+++ b/app/controllers/benefit_forms_controller.rb
@@ -8,9 +8,13 @@ class BenefitFormsController < ApplicationController
   def download
    begin
      path = params[:name]
-     allowed_types = ["AllowedType1", "AllowedType2"] # Replace with actual allowed types
-     if allowed_types.include?(params[:type])
-       file = params[:type].constantize.new(path)
+     allowed_types = {
+       "AllowedType1" => AllowedType1,
+       "AllowedType2" => AllowedType2
+     } # Replace with actual allowed types
+     if allowed_types.key?(params[:type])
+       file_class = allowed_types[params[:type]]
+       file = file_class.new(path)
        send_file file, disposition: "attachment"
      else
        flash[:error] = "Invalid file type"


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/68](https://github.com/Brook-5686/Ruby_3/security/code-scanning/68)

To fix the problem, we need to ensure that the value of `params[:type]` is safe to use with `constantize`. Instead of directly using `params[:type]`, we should map the allowed types to their corresponding classes in a secure manner. This can be achieved by using a hash to map the allowed types to their respective classes and then using this hash to safely retrieve the class.

1. Create a hash that maps allowed types to their corresponding classes.
2. Use this hash to retrieve the class instead of using `constantize` on user input.
3. Replace the direct use of `params[:type].constantize` with a lookup in the hash.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
