### PR TITLE
Fix code scanning alert no. 65: Uncontrolled command line

### DIFF
--- a/app/models/benefits.rb
+++ b/app/models/benefits.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'fileutils'
 class Benefits < ApplicationRecord
 
   def self.save(file, backup = false)
@@ -13,7 +14,8 @@ class Benefits < ApplicationRecord
 
   def self.make_backup(filename, data_path, full_file_name)
     if File.exist?(full_file_name)
-      silence_streams(STDERR) { system("cp #{full_file_name} #{data_path}/bak#{Time.zone.now.to_i}_#{filename}") }
+      backup_file_name = "#{data_path}/bak#{Time.zone.now.to_i}_#{filename}"
+      silence_streams(STDERR) { FileUtils.cp(full_file_name, backup_file_name) }
     end
   end
 


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/65](https://github.com/Brook-5686/Ruby_3/security/code-scanning/65)

To fix the problem, we should avoid using user input directly in the `system` call. Instead, we can use Ruby's built-in file manipulation methods to achieve the same result without invoking a shell command. This approach eliminates the risk of command injection entirely.

The best way to fix the problem is to replace the `system` call with Ruby's `FileUtils.cp` method, which copies files without invoking a shell. This change should be made in the `make_backup` method of the `Benefits` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
