### PR TITLE
Fix code scanning alert no. 67: Code injection

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -13,9 +13,11 @@ class DashboardController < ApplicationController
   end
 
   def change_graph
-    allowed_graphs = ["bar_graph", "pie_charts"]
-    if allowed_graphs.include?(params[:graph])
-      self.try(params[:graph])
+    case params[:graph]
+    when "bar_graph"
+      bar_graph
+    when "pie_charts"
+      pie_charts
     else
       # Handle invalid graph type
       render plain: "Invalid graph type", status: :bad_request
@@ -28,5 +30,16 @@ class DashboardController < ApplicationController
       @user = current_user
       render "dashboard/pie_charts"
     end
+  end
+
+  private
+
+  def bar_graph
+    render "dashboard/bar_graph"
+  end
+
+  def pie_charts
+    @user = current_user
+    render "dashboard/pie_charts"
   end
 end


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/67](https://github.com/Brook-5686/Ruby_3/security/code-scanning/67)

To fix the problem, we should avoid using `self.try` with user input. Instead, we can use a case statement or a hash to map the allowed graph types to their corresponding methods. This way, we can ensure that only the intended methods are called, and no arbitrary code execution can occur.

We will replace the `self.try(params[:graph])` call with a case statement that explicitly calls the appropriate method based on the value of `params[:graph]`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
