### PR TITLE
Fix code scanning alert no. 7: CSRF protection not enabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   # Our security guy keep talking about sea-surfing, cool story bro.
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  #protect_from_forgery with: :exception
+  protect_from_forgery with: :exception
 
   private
 


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/7](https://github.com/Brook-5686/Ruby_3/security/code-scanning/7)

To fix the CSRF vulnerability, we need to enable CSRF protection in the `ApplicationController` by uncommenting the `protect_from_forgery` method and ensuring it raises an exception on an invalid CSRF token. This can be done by using `protect_from_forgery with: :exception`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
