### PR TITLE
Fix code scanning alert no. 15: Clear-text storage of sensitive information

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'bcrypt'
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rails db:seed (or created alongside the db with db:setup).
 #
@@ -7,8 +8,8 @@ users = [
   {
     email: "admin@metacorp.com",
     admin: true,
-    password: "admin1234",
-    password_confirmation: "admin1234",
+    password: BCrypt::Password.create("admin1234"),
+    password_confirmation: BCrypt::Password.create("admin1234"),
     first_name: "Admin",
     last_name: "",
   },
@@ -16,8 +17,8 @@ users = [
   {
     email: "jmmastey@metacorp.com",
     admin: false,
-    password: "railsgoat!",
-    password_confirmation: "railsgoat!",
+    password: BCrypt::Password.create("railsgoat!"),
+    password_confirmation: BCrypt::Password.create("railsgoat!"),
     first_name: "Joseph",
     last_name: "Mastey",
   },
@@ -25,8 +26,8 @@ users = [
   {
     email: "jack@metacorp.com",
     admin: false,
-    password: "yankeessuck",
-    password_confirmation: "yankeessuck",
+    password: BCrypt::Password.create("yankeessuck"),
+    password_confirmation: BCrypt::Password.create("yankeessuck"),
     first_name: "Jack",
     last_name: "Mannino",
   },


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/15](https://github.com/Brook-5686/Ruby_3/security/code-scanning/15)

To fix the problem, we need to ensure that passwords are hashed before being stored in the database. This can be achieved by using a hashing function provided by a well-known library such as `bcrypt`. The `bcrypt` library is commonly used in Ruby on Rails applications for securely hashing passwords.

1. Install the `bcrypt` gem if it is not already included in the project.
2. Update the seed file to hash the passwords before creating user records.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
