### PR TITLE
Fix code scanning alert no. 12: SQL query built from user-controlled sources

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,7 +26,7 @@ class UsersController < ApplicationController
   def update
     message = false
 
-    user = User.where("id = '#{params[:user][:id]}'")[0]
+    user = User.where(id: params[:user][:id]).first
 
     if user
       user.update(user_params_without_password)


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/12](https://github.com/Brook-5686/Ruby_3/security/code-scanning/12)

To fix the SQL injection vulnerability, we should use parameterized queries provided by ActiveRecord. Instead of directly interpolating the user-controlled parameter into the SQL query string, we can pass the parameter as a value in a hash. This ensures that the parameter is properly escaped and prevents SQL injection attacks.

- Replace the vulnerable line with a parameterized query using a hash.
- Ensure that the functionality remains the same by fetching the user based on the provided `id`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
