### PR TITLE
Fix code scanning alert no. 11: SQL query built from user-controlled sources

### DIFF
--- a/app/models/analytics.rb
+++ b/app/models/analytics.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Analytics < ApplicationRecord
-  scope :hits_by_ip, ->(ip, col = "*") { select("#{col}").where(ip_address: ip).order("id DESC") }
+  scope :hits_by_ip, ->(ip, col = "*") { select(parse_field(col)).where(ip_address: ip).order("id DESC") }
 
   def self.count_by_col(col)
     calculate(:count, col)


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/11](https://github.com/Brook-5686/Ruby_3/security/code-scanning/11)

To fix the problem, we need to ensure that the `col` parameter is sanitized and validated before being used in the SQL query. The best way to achieve this is to use a whitelist of allowed column names and only allow those columns to be used in the query. We can modify the `hits_by_ip` scope to use the `parse_field` method to validate the `col` parameter.

1. Modify the `hits_by_ip` scope in `app/models/analytics.rb` to use the `parse_field` method to validate the `col` parameter.
2. Ensure that the `parse_field` method is used to sanitize the `col` parameter before it is used in the `select` statement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
