### PR TITLE
Fix code scanning alert no. 10: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "encryption"
+require "bcrypt"
 
 class User < ApplicationRecord
   validates :password, presence: true,
@@ -42,7 +43,7 @@ class User < ApplicationRecord
     auth = nil
     user = find_by_email(email)
     raise "#{email} doesn't exist!" if !(user)
-    if user.password == Digest::MD5.hexdigest(password)
+    if BCrypt::Password.new(user.password) == password
       auth = user
     else
       raise "Incorrect Password!"
@@ -52,7 +53,7 @@ class User < ApplicationRecord
 
   def hash_password
     if will_save_change_to_password?
-      self.password = Digest::MD5.hexdigest(self.password)
+      self.password = BCrypt::Password.create(self.password)
     end
   end
 


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/10](https://github.com/Brook-5686/Ruby_3/security/code-scanning/10)

To fix the problem, we need to replace the use of the MD5 hashing algorithm with a stronger, more secure algorithm suitable for password hashing. One of the best options is to use the `bcrypt` algorithm, which is designed specifically for hashing passwords and is computationally expensive, making it resistant to brute-force attacks.

Steps to fix the issue:
1. Install the `bcrypt` gem if it is not already installed.
2. Update the `hash_password` method to use `bcrypt` for hashing passwords.
3. Update the `authenticate` method to use `bcrypt` for verifying passwords.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
