### PR TITLE
Fix code scanning alert no. 45: DOM text reinterpreted as HTML

### DIFF
--- a/app/assets/javascripts/bootstrap.js
+++ b/app/assets/javascripts/bootstrap.js
@@ -1659,9 +1659,9 @@
       , target = $this.attr('data-target')
         || e.preventDefault()
         || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
-      , option = $(target).data('collapse') ? 'toggle' : $this.data()
-    $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
-    $(target).collapse(option)
+      , option = $.find(target).data('collapse') ? 'toggle' : $this.data()
+    $this[$.find(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
+    $.find(target).collapse(option)
   })
 
 }(window.jQuery);


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/45](https://github.com/Brook-5686/Ruby_3/security/code-scanning/45)

To fix the problem, we need to ensure that the `target` variable is treated as a CSS selector and not as HTML. This can be achieved by using the `$.find` method instead of `$`, which will interpret `target` strictly as a CSS selector. This change will prevent the execution of arbitrary JavaScript and mitigate the XSS vulnerability.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
