### PR TITLE
Fix code scanning alert no. 49: DOM text reinterpreted as HTML

### DIFF
--- a/app/views/benefit_forms/index.html.erb
+++ b/app/views/benefit_forms/index.html.erb
@@ -1,3 +1,4 @@
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js"></script>
 <div class="dashboard-wrapper">
   <div class="main-container">
 
@@ -114,7 +115,7 @@
   $(function() {
     $("#benefits_upload").change(function (){
       var fileName = $(this).val();
-      $(".filename").html(fileName);
+      $(".filename").html(_.escape(fileName));
     });
   });
 


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/49](https://github.com/Brook-5686/Ruby_3/security/code-scanning/49)

To fix the problem, we need to ensure that the `fileName` variable is properly escaped before being inserted into the HTML. This can be done using a method that safely encodes the text to prevent any HTML or JavaScript from being executed.

The best way to fix this issue is to use a library like `lodash` to escape the `fileName` before inserting it into the HTML. The `_.escape` function from `lodash` can be used to convert the `fileName` into a safe string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
