### PR TITLE
Fix code scanning alert no. 42: DOM text reinterpreted as HTML

### DIFF
--- a/app/assets/javascripts/bootstrap.js
+++ b/app/assets/javascripts/bootstrap.js
@@ -688,7 +688,7 @@
 
       if (e.isDefaultPrevented()) return
 
-      $target = $(selector)
+      $target = $ul.find(selector)
 
       this.activate($this.parent('li'), $ul)
       this.activate($target, $target.parent(), function () {


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/42](https://github.com/Brook-5686/Ruby_3/security/code-scanning/42)

To fix the problem, we need to ensure that the value of the `data-target` attribute is properly sanitized before it is used as a selector. One way to do this is to use the `$.find` method instead of `$`, which will interpret the value strictly as a CSS selector and not as HTML. This change will prevent the possibility of XSS attacks by ensuring that the value is treated as a selector and not as executable code.

We will modify the code in the `show` method of the `Tab` prototype to use `$.find` instead of `$` when selecting the target element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
