### PR TITLE
Fix code scanning alert no. 48: DOM text reinterpreted as HTML

### DIFF
--- a/app/assets/javascripts/bootstrap.js
+++ b/app/assets/javascripts/bootstrap.js
@@ -1843,7 +1843,8 @@
 
   $(document).on('click.carousel.data-api', '[data-slide]', function (e) {
     var $this = $(this), href
-      , $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
+      , targetSelector = $this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
+      , $target = $(document.querySelector(targetSelector))
       , options = $.extend({}, $target.data(), $this.data())
     $target.carousel(options)
     e.preventDefault()


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/48](https://github.com/Brook-5686/Ruby_3/security/code-scanning/48)

To fix the problem, we need to ensure that the `data-target` attribute is not interpreted as HTML. Instead of using `$` to select the target element, we should use a method that treats the input as a CSS selector and not as HTML. The best way to fix this is to use `document.querySelector` or jQuery's `$.find` method, which will interpret the input strictly as a CSS selector.

We will replace the line where the `data-target` attribute is used with a safer alternative. Specifically, we will use `document.querySelector` to ensure that the input is treated as a CSS selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
