### PR TITLE
Fix code scanning alert no. 38: Unsafe jQuery plugin

### DIFF
--- a/app/assets/javascripts/bootstrap.js
+++ b/app/assets/javascripts/bootstrap.js
@@ -1531,7 +1531,7 @@
     this.options = $.extend({}, $.fn.collapse.defaults, options)
 
     if (this.options.parent) {
-      this.$parent = $(this.options.parent)
+      this.$parent = $.find(this.options.parent)
     }
 
     this.options.toggle && this.toggle()


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/38](https://github.com/Brook-5686/Ruby_3/security/code-scanning/38)

To fix the problem, we need to ensure that the `parent` option is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly passing the `parent` option to the jQuery constructor. This change will prevent the evaluation of the `parent` option as HTML, thus mitigating the XSS risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
