### PR TITLE
Fix code scanning alert no. 31: Unsafe HTML constructed from library input

### DIFF
--- a/app/assets/javascripts/jquery.snippet.js
+++ b/app/assets/javascripts/jquery.snippet.js
@@ -193,8 +193,26 @@
 					// collapse functionality
 					if(defaults.collapse){
 						var styleClass = o.parent().attr('class');
-						var collapseShow = "<div class='snippet-reveal "+styleClass+"'><pre class='sh_sourceCode'><a href='#' class='snippet-toggle'>"+defaults.showMsg+"</a></pre></div>";
-						var collapseHide = "<div class='sh_sourceCode snippet-hide'><pre><a href='#' class='snippet-revealed snippet-toggle'>"+defaults.hideMsg+"</a></pre></div>";
+						var collapseShow = document.createElement('div');
+						collapseShow.className = 'snippet-reveal ' + styleClass;
+						var preShow = document.createElement('pre');
+						preShow.className = 'sh_sourceCode';
+						var aShow = document.createElement('a');
+						aShow.href = '#';
+						aShow.className = 'snippet-toggle';
+						aShow.textContent = defaults.showMsg;
+						preShow.appendChild(aShow);
+						collapseShow.appendChild(preShow);
+						
+						var collapseHide = document.createElement('div');
+						collapseHide.className = 'sh_sourceCode snippet-hide';
+						var preHide = document.createElement('pre');
+						var aHide = document.createElement('a');
+						aHide.href = '#';
+						aHide.className = 'snippet-revealed snippet-toggle';
+						aHide.textContent = defaults.hideMsg;
+						preHide.appendChild(aHide);
+						collapseHide.appendChild(preHide);
 						
 						o.parents('.snippet-container').append(collapseShow);
 						o.parent().append(collapseHide);


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/31](https://github.com/Brook-5686/Ruby_3/security/code-scanning/31)

To fix the problem, we need to ensure that any dynamic HTML construction involving user input is properly sanitized or escaped to prevent XSS attacks. The best way to fix this issue without changing existing functionality is to use a safe API or sanitize the input before using it in HTML construction.

In this case, we can use the `textContent` property to safely insert text into the HTML, which will prevent any HTML from being interpreted. Alternatively, we can use a library like `DOMPurify` to sanitize the input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
