### PR TITLE
Fix code scanning alert no. 5: Reflected server-side cross-site scripting

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -34,7 +34,7 @@ class PasswordResetsController < ApplicationController
       flash[:success] = "Password reset email sent to #{params[:email]}"
       redirect_to :login
     else
-      flash[:error] = "There was an issue sending password reset email to #{params[:email]}".html_safe unless params[:email].nil?
+      flash[:error] = "There was an issue sending password reset email to #{params[:email]}" unless params[:email].nil?
     end
   end
 


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/5](https://github.com/Brook-5686/Ruby_3/security/code-scanning/5)

To fix the problem, we need to ensure that the user input is properly escaped before being rendered. In this case, we should avoid using `html_safe` on the string that includes user input. Instead, we can use Rails' built-in escaping mechanisms to ensure that the user input is safely rendered.

The best way to fix this issue is to remove the `html_safe` call and let Rails handle the escaping automatically. This will ensure that any potentially malicious input is properly escaped before being rendered.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
