### PR TITLE
Fix code scanning alert no. 37: Unsafe jQuery plugin

### DIFF
--- a/app/assets/javascripts/bootstrap.js
+++ b/app/assets/javascripts/bootstrap.js
@@ -499,9 +499,11 @@
       , href
     this.options = $.extend({}, $.fn.scrollspy.defaults, options)
     this.$scrollElement = $element.on('scroll.scroll-spy.data-api', process)
-    this.selector = (this.options.target
-      || ((href = $(element).attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
-      || '') + ' .nav li > a'
+    var target = this.options.target || ((href = $(element).attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) || '';
+    if (!/^#[\w-]+$/.test(target)) {
+      throw new Error('Invalid target selector');
+    }
+    this.selector = target + ' .nav li > a'
     this.$body = $('body')
     this.refresh()
     this.process()


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/37](https://github.com/Brook-5686/Ruby_3/security/code-scanning/37)

To fix the problem, we need to ensure that the `option` parameter is properly sanitized before being used to construct the CSS selector. This can be achieved by validating the `option` parameter to ensure it does not contain any potentially harmful characters or patterns. Specifically, we can use a regular expression to validate that the `option` parameter only contains valid CSS selector characters.

We will modify the `ScrollSpy` constructor to include this validation step. If the `option` parameter is invalid, we can either throw an error or sanitize it to a safe default value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
