### PR TITLE
Fix code scanning alert no. 25: Unsafe HTML constructed from library input

### DIFF
--- a/app/assets/javascripts/date-picker/daterangepicker.js
+++ b/app/assets/javascripts/date-picker/daterangepicker.js
@@ -85,6 +85,15 @@
             }
         }
 
+        function sanitizeInput(input) {
+            var element = document.createElement('div');
+            element.innerText = input;
+            return element.innerHTML;
+        }
+
+        this.applyClass = sanitizeInput(this.applyClass);
+        this.clearClass = sanitizeInput(this.clearClass);
+
         var DRPTemplate = '<div class="daterangepicker dropdown-menu">' +
                 '<div class="calendar left"></div>' +
                 '<div class="calendar right"></div>' +


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_3/security/code-scanning/25](https://github.com/Brook-5686/Ruby_3/security/code-scanning/25)

To fix the problem, we need to ensure that any user-controlled input used in constructing HTML is properly sanitized. This can be achieved by using safe APIs or sanitizing the input before using it in HTML construction.

The best way to fix this issue without changing existing functionality is to sanitize the `applyClass` and `clearClass` values before using them in the HTML template. We can use a simple sanitization function to remove any potentially harmful characters or tags.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
